### PR TITLE
dx(cdk): allow running cdk commands from root

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
     "name": "eliza",
     "scripts": {
+        "cdk": "pnpm --filter=@ai16z/cdk build && pnpm --filter=@ai16z/cdk cdk",
         "preinstall": "npx only-allow pnpm",
         "build": "turbo run build --filter=!eliza-docs",
         "build-docker": "turbo run build",


### PR DESCRIPTION
I like running `pnpm cdk deploy` from root