### PR TITLE
feat(cdk): refactor Eliza AI infrastructure and introduce new stacks

### DIFF
--- a/packages/cdk/src/index.ts
+++ b/packages/cdk/src/index.ts
@@ -1,101 +1,18 @@
 import * as cdk from "aws-cdk-lib";
-import * as ec2 from "aws-cdk-lib/aws-ec2";
-import * as ecs from "aws-cdk-lib/aws-ecs";
-import * as iam from "aws-cdk-lib/aws-iam";
-import * as ecr from "aws-cdk-lib/aws-ecr";
-import { Construct } from "constructs";
-
-export class ElizaAIStack extends cdk.Stack {
-    constructor(scope: Construct, id: string, props?: cdk.StackProps) {
-        super(scope, id, props);
-
-        // Create VPC
-        const vpc = new ec2.Vpc(this, "ElizaVPC", {
-            maxAzs: 2,
-            natGateways: 1, // Reduce costs by using only one NAT gateway
-        });
-
-        // Create ECR repository for our Docker images
-        const repository = new ecr.Repository(this, "ElizaRepository", {
-            repositoryName: "eliza-ai",
-            removalPolicy: cdk.RemovalPolicy.DESTROY, // For development; change for production
-        });
-
-        // Create ECS Cluster
-        const cluster = new ecs.Cluster(this, "ElizaCluster", {
-            vpc,
-        });
-
-        // Create Fargate Task Role
-        const taskRole = new iam.Role(this, "ElizaTaskRole", {
-            assumedBy: new iam.ServicePrincipal("ecs-tasks.amazonaws.com"),
-        });
-
-        // Create Fargate Task Definition
-        const taskDefinition = new ecs.FargateTaskDefinition(
-            this,
-            "ElizaTaskDef",
-            {
-                memoryLimitMiB: 512, // Minimum memory for cost efficiency
-                cpu: 256, // 0.25 vCPU
-                taskRole,
-            }
-        );
-
-        // Add container to task definition
-        taskDefinition.addContainer("ElizaContainer", {
-            image: ecs.ContainerImage.fromEcrRepository(repository),
-            memoryLimitMiB: 512,
-            logging: ecs.LogDrivers.awsLogs({ streamPrefix: "eliza-ai" }),
-            environment: {
-                NODE_ENV: "production",
-                // TODO: Replace in-memory database with PostgreSQL configuration
-                DATABASE_TYPE: "memory",
-            },
-            portMappings: [{ containerPort: 3000 }],
-        });
-
-        // Create Fargate Service
-        const service = new ecs.FargateService(this, "ElizaService", {
-            cluster,
-            taskDefinition,
-            desiredCount: 1, // Start with one instance
-            assignPublicIp: true, // Required for pulling images and other external communications
-            vpcSubnets: {
-                subnetType: ec2.SubnetType.PUBLIC,
-            },
-        });
-
-        // Add security group rules
-        const securityGroup = new ec2.SecurityGroup(
-            this,
-            "ElizaSecurityGroup",
-            {
-                vpc,
-                description: "Security group for Eliza AI service",
-                allowAllOutbound: true,
-            }
-        );
-
-        securityGroup.addIngressRule(
-            ec2.Peer.anyIpv4(),
-            ec2.Port.tcp(3000),
-            "Allow inbound HTTP traffic"
-        );
-
-        service.connections.addSecurityGroup(securityGroup);
-
-        // Output the repository URI
-        new cdk.CfnOutput(this, "RepositoryUri", {
-            value: repository.repositoryUri,
-            description: "ECR Repository URI",
-        });
-    }
-}
+import { ElizaFleetStack } from "./stacks/ElizaFleetStack";
+import { GitHubActionsStack } from "./stacks/GithubActionsStack";
 
 // Initialize the CDK app
 const app = new cdk.App();
-new ElizaAIStack(app, "ElizaAIStack", {
+
+new ElizaFleetStack(app, "ElizaFleetStack", {
+    env: {
+        account: process.env.CDK_DEFAULT_ACCOUNT,
+        region: process.env.CDK_DEFAULT_REGION,
+    },
+});
+
+new GitHubActionsStack(app, "GitHubActionsStack", {
     env: {
         account: process.env.CDK_DEFAULT_ACCOUNT,
         region: process.env.CDK_DEFAULT_REGION,

--- a/packages/cdk/src/stacks/ElizaFleetStack.ts
+++ b/packages/cdk/src/stacks/ElizaFleetStack.ts
@@ -1,0 +1,94 @@
+import * as cdk from "aws-cdk-lib";
+import * as ec2 from "aws-cdk-lib/aws-ec2";
+import * as ecs from "aws-cdk-lib/aws-ecs";
+import * as iam from "aws-cdk-lib/aws-iam";
+import * as ecr from "aws-cdk-lib/aws-ecr";
+import { Construct } from "constructs";
+
+export class ElizaFleetStack extends cdk.Stack {
+    constructor(scope: Construct, id: string, props?: cdk.StackProps) {
+        super(scope, id, props);
+
+        // Create VPC
+        const vpc = new ec2.Vpc(this, "ElizaVPC", {
+            maxAzs: 2,
+            natGateways: 1, // Reduce costs by using only one NAT gateway
+        });
+
+        // Create ECR repository for our Docker images
+        const repository = new ecr.Repository(this, "ElizaRepository", {
+            repositoryName: "eliza-ai",
+            removalPolicy: cdk.RemovalPolicy.DESTROY, // For development; change for production
+        });
+
+        // Create ECS Cluster
+        const cluster = new ecs.Cluster(this, "ElizaCluster", {
+            vpc,
+        });
+
+        // Create Fargate Task Role
+        const taskRole = new iam.Role(this, "ElizaTaskRole", {
+            assumedBy: new iam.ServicePrincipal("ecs-tasks.amazonaws.com"),
+        });
+
+        // Create Fargate Task Definition
+        const taskDefinition = new ecs.FargateTaskDefinition(
+            this,
+            "ElizaTaskDef",
+            {
+                memoryLimitMiB: 512, // Minimum memory for cost efficiency
+                cpu: 256, // 0.25 vCPU
+                taskRole,
+            }
+        );
+
+        // Add container to task definition
+        taskDefinition.addContainer("ElizaContainer", {
+            image: ecs.ContainerImage.fromEcrRepository(repository),
+            memoryLimitMiB: 512,
+            logging: ecs.LogDrivers.awsLogs({ streamPrefix: "eliza-ai" }),
+            environment: {
+                NODE_ENV: "production",
+                // TODO: Replace in-memory database with PostgreSQL configuration
+                DATABASE_TYPE: "memory",
+            },
+            portMappings: [{ containerPort: 3000 }],
+        });
+
+        // Create Fargate Service
+        const service = new ecs.FargateService(this, "ElizaService", {
+            cluster,
+            taskDefinition,
+            desiredCount: 1, // Start with one instance
+            assignPublicIp: true, // Required for pulling images and other external communications
+            vpcSubnets: {
+                subnetType: ec2.SubnetType.PUBLIC,
+            },
+        });
+
+        // Add security group rules
+        const securityGroup = new ec2.SecurityGroup(
+            this,
+            "ElizaSecurityGroup",
+            {
+                vpc,
+                description: "Security group for Eliza AI service",
+                allowAllOutbound: true,
+            }
+        );
+
+        securityGroup.addIngressRule(
+            ec2.Peer.anyIpv4(),
+            ec2.Port.tcp(3000),
+            "Allow inbound HTTP traffic"
+        );
+
+        service.connections.addSecurityGroup(securityGroup);
+
+        // Output the repository URI
+        new cdk.CfnOutput(this, "RepositoryUri", {
+            value: repository.repositoryUri,
+            description: "ECR Repository URI",
+        });
+    }
+}

--- a/packages/cdk/src/stacks/GithubActionsStack.ts
+++ b/packages/cdk/src/stacks/GithubActionsStack.ts
@@ -1,0 +1,40 @@
+import * as cdk from "aws-cdk-lib";
+import * as iam from "aws-cdk-lib/aws-iam";
+
+export class GitHubActionsStack extends cdk.Stack {
+    constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+        super(scope, id, props);
+
+        // Define the OIDC provider
+        const oidcProvider = new iam.OpenIdConnectProvider(
+            this,
+            "GitHubOIDCProvider",
+            {
+                url: "https://token.actions.githubusercontent.com",
+                clientIds: ["sts.amazonaws.com"],
+            }
+        );
+
+        // Define the IAM role
+        const githubActionsRole = new iam.Role(this, "GitHubActionsRole", {
+            assumedBy: new iam.WebIdentityPrincipal(
+                oidcProvider.openIdConnectProviderArn,
+                {
+                    StringEquals: {
+                        "token.actions.githubusercontent.com:aud":
+                            "sts.amazonaws.com",
+                    },
+                }
+            ),
+            description: "Role for GitHub Actions to access AWS resources",
+        });
+
+        // Attach necessary policies
+        githubActionsRole.addToPolicy(
+            new iam.PolicyStatement({
+                actions: ["ecr:GetAuthorizationToken"],
+                resources: ["*"],
+            })
+        );
+    }
+}


### PR DESCRIPTION
feat(cdk): refactor Eliza AI infrastructure and introduce new stacks

- Removed the original ElizaAIStack and replaced it with two new stacks: ElizaFleetStack and GitHubActionsStack.
- ElizaFleetStack provisions the ECS Fargate service, VPC, ECR repository, and security group, maintaining the previous infrastructure setup.
- GitHubActionsStack defines an IAM role for GitHub Actions with OIDC provider integration, allowing secure access to AWS resources.
- Updated the main entry point to initialize the new stacks, ensuring a modular architecture for better maintainability.