### PR TITLE
chore: update .dockerignore to improve caching for GitHub Actions workflows

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,7 @@
+# Enable more cache hits in .github/workflows/deploy.yml
+# because I'll be making lots of changes to these files
+.packages/cdk/
+
 # Development artifacts and dependencies
 .git/
 .github/


### PR DESCRIPTION
chore: update .dockerignore to improve caching for GitHub Actions workflows

- Added a new entry to .dockerignore to exclude the .packages/cdk/ directory, enhancing cache hits during Docker builds in the GitHub Actions deploy workflow.
- This change aims to optimize the build process by preventing unnecessary files from being included, thereby improving efficiency.