### PR TITLE
refactor: update README and GitHub Actions workflow for improved deployment process

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,9 +6,9 @@ on:
             - main-lachie
 
 jobs:
-    docker_build:
+    docker_build_eliza_agent:
         runs-on: ubuntu-latest
-        timeout-minutes: 15
+        timeout-minutes: 20
 
         # https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/controlling-permissions-for-github_token
         permissions:
@@ -21,10 +21,16 @@ jobs:
 
         env:
             # Required for ECR login
-            AWS_ECR_REGISTRY: ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_REGION }}.amazonaws.com
+            AWS_ECR_REGISTRY: ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ env.AWS_REGION }}.amazonaws.com
 
-            # Tag the image with the commit that triggered the build
+            # Deploy the image built in the previous job
             GIT_COMMIT_SHA: ${{ github.sha }}
+
+            # Created in github-actions stack to deploy other stacks on GitHub Actions
+            AWS_ROLE_NAME: github-actions-role
+
+            # Required for AWS region
+            AWS_REGION: us-east-1
 
         steps:
             - uses: actions/checkout@v4
@@ -33,12 +39,12 @@ jobs:
             - name: Login to AWS
               uses: aws-actions/configure-aws-credentials@v4.0.2
               with:
-                  role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/${{ secrets.AWS_ROLE_NAME }}
-                  aws-region: ${{ secrets.AWS_REGION }}
+                  role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/${{ env.AWS_ROLE_NAME }}
+                  aws-region: ${{ env.AWS_REGION }}
 
             # Required for push to ECR
             - name: ECR Login
-              run: aws ecr get-login-password --region ${{ secrets.AWS_REGION }} | docker login --username AWS --password-stdin ${{ env.AWS_ECR_REGISTRY }}
+              run: aws ecr get-login-password --region ${{ env.AWS_REGION }} | docker login --username AWS --password-stdin ${{ env.AWS_ECR_REGISTRY }}
 
             - name: Set up QEMU
               uses: docker/setup-qemu-action@v3
@@ -54,10 +60,10 @@ jobs:
                   cache-from: type=gha
                   cache-to: type=gha,mode=max
 
-    cdk_deploy:
-        needs: [docker_build]
+    cdk_deploy_eliza_fleet:
+        needs: [docker_build_eliza_agent]
         runs-on: ubuntu-latest
-        timeout-minutes: 15
+        timeout-minutes: 20
 
         # https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/controlling-permissions-for-github_token
         permissions:
@@ -66,7 +72,7 @@ jobs:
 
         # Disable concurrency to ensure that the deploy job always completes without being cancelled
         concurrency:
-            group: deploy
+            group: cdk_deploy
             cancel-in-progress: false
 
         # Load vars and secrets from this environment
@@ -76,6 +82,12 @@ jobs:
         env:
             # Deploy the image built in the previous job
             GIT_COMMIT_SHA: ${{ github.sha }}
+            # Required for AWS role
+            AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID }}
+            # Required for AWS region
+            AWS_REGION: us-east-1
+            # Created in github-actions stack to deploy other stacks on GitHub Actions
+            AWS_ROLE_NAME: github-actions-role
 
         steps:
             - uses: actions/checkout@v4
@@ -84,8 +96,8 @@ jobs:
             - name: Login to AWS
               uses: aws-actions/configure-aws-credentials@v4.0.2
               with:
-                  role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/${{ secrets.AWS_ROLE_NAME }}
-                  aws-region: ${{ secrets.AWS_REGION }}
+                  role-to-assume: arn:aws:iam::${{ secrets.AWS_ACCOUNT_ID }}:role/${{ env.AWS_ROLE_NAME }}
+                  aws-region: ${{ env.AWS_REGION }}
 
             - uses: pnpm/action-setup@v3
               with:
@@ -102,7 +114,7 @@ jobs:
 
             # Generate CDK diff for logging purposes
             - name: Generate CDK diff
-              run: pnpm cdk diff --require-approval never ElizaFleetStack
+              run: pnpm cdk diff --require-approval never eliza-fleet
 
             # - name: CDK Deploy
-            #   run: pnpm cdk deploy --require-approval never ElizaFleetStack
+            #   run: pnpm cdk deploy --require-approval never eliza-fleet

--- a/README.md
+++ b/README.md
@@ -18,8 +18,6 @@ This guide will walk you through the process of setting up your own agents by fo
 3. Set branch protection rules to ensure only authorized changes are made to the main branch.
 4. Within the `eliza-fleet` environment, add the following secrets:
     - `AWS_ACCOUNT_ID`: Your AWS account ID.
-    - `AWS_REGION`: The AWS region you are using (e.g., `us-east-1`).
-    - `AWS_ROLE_NAME`: The name of the IAM role for GitHub Actions.
 
 ### Step 3: Deploy AWS OIDC Setup Locally
 
@@ -52,7 +50,8 @@ This guide will walk you through the process of setting up your own agents by fo
 5. Deploy the CDK stack to set up the OIDC provider and IAM roles:
 
     ```bash
-    pnpm cdk deploy GitHubActionsStack
+    export GITHUB_REPOSITORY=lachiejames/eliza-fleet
+    pnpm cdk deploy github-actions
     ```
 
     This will create the necessary AWS resources for GitHub Actions to authenticate using OIDC.


### PR DESCRIPTION
refactor: update README and GitHub Actions workflow for improved deployment process

- Removed AWS_REGION and AWS_ROLE_NAME from README secrets section for clarity.
- Updated deployment commands in README to reflect the new stack name 'github-actions'.
- Renamed jobs in deploy.yml for better clarity: 'docker_build' to 'docker_build_eliza_agent' and 'cdk_deploy' to 'cdk_deploy_eliza_fleet'.
- Increased timeout for Docker build and CDK deploy jobs from 15 to 20 minutes.
- Adjusted environment variable references in deploy.yml to use 'env' for AWS_REGION and AWS_ROLE_NAME, ensuring consistency across jobs.