### PR TITLE
fix deploy pipeline

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,6 +5,13 @@ on:
         branches:
             - main-lachie
 
+env:
+    # Created in github-actions stack to deploy other stacks on GitHub Actions
+    AWS_ROLE_NAME: github-actions-role
+
+    # Required for AWS region
+    AWS_REGION: us-east-1
+
 jobs:
     docker_build_eliza_agent:
         runs-on: ubuntu-latest
@@ -21,16 +28,10 @@ jobs:
 
         env:
             # Required for ECR login
-            AWS_ECR_REGISTRY: ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ env.AWS_REGION }}.amazonaws.com
+            AWS_ECR_REGISTRY: ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.us-east-1.amazonaws.com
 
             # Deploy the image built in the previous job
             GIT_COMMIT_SHA: ${{ github.sha }}
-
-            # Created in github-actions stack to deploy other stacks on GitHub Actions
-            AWS_ROLE_NAME: github-actions-role
-
-            # Required for AWS region
-            AWS_REGION: us-east-1
 
         steps:
             - uses: actions/checkout@v4
@@ -84,10 +85,6 @@ jobs:
             GIT_COMMIT_SHA: ${{ github.sha }}
             # Required for AWS role
             AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID }}
-            # Required for AWS region
-            AWS_REGION: us-east-1
-            # Created in github-actions stack to deploy other stacks on GitHub Actions
-            AWS_ROLE_NAME: github-actions-role
 
         steps:
             - uses: actions/checkout@v4


### PR DESCRIPTION
### TL;DR
Moved AWS environment variables to global scope in GitHub Actions workflow

### What changed?
- Relocated `AWS_ROLE_NAME` and `AWS_REGION` from job-level to workflow-level environment variables
- Hardcoded region value in ECR registry URL to maintain consistency
- Removed redundant environment variable declarations from individual jobs

### How to test?
1. Push a commit to the `main-lachie` branch
2. Verify the GitHub Actions workflow executes successfully
3. Confirm AWS authentication and ECR operations work as expected

### Why make this change?
Centralizing AWS configuration variables at the workflow level reduces redundancy and makes the workflow more maintainable. This change also ensures consistent AWS region usage across all jobs in the workflow.