### PR TITLE
feat(cdk): disable automated backups for Eliza RDS instance during development

### DIFF
--- a/packages/cdk/src/aws/rds/createElizaRDSInstance.ts
+++ b/packages/cdk/src/aws/rds/createElizaRDSInstance.ts
@@ -41,6 +41,7 @@ export const createElizaRDSInstance = ({
         publiclyAccessible: !isPrivate,
         removalPolicy: cdk.RemovalPolicy.DESTROY,
         deletionProtection: false,
+        backupRetention: cdk.Duration.days(0), // Disable automated backups while in development
     });
 
     return database;


### PR DESCRIPTION
feat(cdk): disable automated backups for Eliza RDS instance during development

- Updated the RDS instance configuration to set backup retention to zero days, disabling automated backups while in the development phase. This change aims to streamline the development process and reduce unnecessary resource usage.