### PR TITLE
chore(cdk): upgrade PostgreSQL engine version for Eliza RDS instance from 13.18 to 15.10

### DIFF
--- a/packages/cdk/src/aws/rds/createElizaRDSInstance.ts
+++ b/packages/cdk/src/aws/rds/createElizaRDSInstance.ts
@@ -20,7 +20,7 @@ export const createElizaRDSInstance = ({
         }),
         databaseName: "eliza",
         engine: rds.DatabaseInstanceEngine.postgres({
-            version: rds.PostgresEngineVersion.VER_13_18,
+            version: rds.PostgresEngineVersion.VER_15_10,
         }),
         instanceType: ec2.InstanceType.of(
             ec2.InstanceClass.T4G,


### PR DESCRIPTION
### TL;DR
Upgraded PostgreSQL version from 13.18 to 15.10 in the Eliza RDS instance.

### What changed?
Updated the PostgreSQL engine version in the RDS instance configuration from version 13.18 to 15.10.

### How to test?
1. Deploy the infrastructure changes
2. Verify the RDS instance is created with PostgreSQL 15.10
3. Confirm database connectivity and functionality
4. Check if existing applications work correctly with the new version

### Why make this change?
PostgreSQL 15 brings performance improvements, better monitoring capabilities, and enhanced security features. Keeping the database engine up-to-date ensures we have access to the latest features and security patches.