### PR TITLE
fix(cdk): update package names for consistency and clarity

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "eliza",
     "scripts": {
-        "cdk": "pnpm --filter=@eliza/cdk build && pnpm --filter=@eliza/cdk cdk",
+        "cdk": "pnpm --filter=@elizaos/cdk build && pnpm --filter=@elizaos/cdk cdk",
         "preinstall": "npx only-allow pnpm",
         "build": "turbo run build --filter=!eliza-docs",
         "build-docker": "turbo run build",

--- a/packages/cdk/package.json
+++ b/packages/cdk/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "@eliza/cdk",
+    "name": "@elizaos/cdk",
     "version": "0.1.6",
     "main": "dist/index.js",
     "type": "module",


### PR DESCRIPTION
fix(cdk): update package names for consistency and clarity

- Changed the package name from "@eliza/cdk" to "@elizaos/cdk" in both the root package.json and the cdk package.json.
- Updated the build script in the root package.json to reflect the new package name, ensuring that commands are executed correctly.

These changes enhance consistency across the project and align with the naming conventions used in the repository.