### PR TITLE
feat(cdk): add Redis security group and ElastiCache Redis instance for improved caching (#16)

### DIFF
--- a/packages/cdk/src/aws/ec2/createRedisSecurityGroup.ts
+++ b/packages/cdk/src/aws/ec2/createRedisSecurityGroup.ts
@@ -1,0 +1,24 @@
+import * as cdk from "aws-cdk-lib";
+import * as ec2 from "aws-cdk-lib/aws-ec2";
+
+/**
+ * Creates a security group for Redis instance
+ * This security group controls network access to the Redis instance
+ */
+export function createRedisSecurityGroup({
+    scope,
+    vpc,
+}: {
+    scope: cdk.Stack;
+    vpc: ec2.IVpc;
+}): ec2.SecurityGroup {
+    const securityGroupName = `${scope.stackName}-redis-security-group`;
+    const securityGroup = new ec2.SecurityGroup(scope, "RedisSecurityGroup", {
+        vpc,
+        securityGroupName,
+        description: "Security group for Redis instance",
+        allowAllOutbound: true,
+    });
+
+    return securityGroup;
+}

--- a/packages/cdk/src/aws/elasticache/createElizaRedisInstance.ts
+++ b/packages/cdk/src/aws/elasticache/createElizaRedisInstance.ts
@@ -1,0 +1,46 @@
+import * as cdk from "aws-cdk-lib";
+import * as ec2 from "aws-cdk-lib/aws-ec2";
+import * as elasticache from "aws-cdk-lib/aws-elasticache";
+
+/**
+ * Creates an ElastiCache Redis instance for Eliza
+ * This Redis instance is used for caching and session management
+ */
+export function createElizaRedisInstance({
+    scope,
+    vpc,
+    securityGroup,
+    isPrivate,
+}: {
+    scope: cdk.Stack;
+    vpc: ec2.IVpc;
+    securityGroup: ec2.SecurityGroup;
+    isPrivate: boolean;
+}): elasticache.CfnCacheCluster {
+    const cacheSubnetGroupName = `${scope.stackName}-redis-subnet-group`;
+    const subnetGroup = new elasticache.CfnSubnetGroup(
+        scope,
+        "RedisSubnetGroup",
+        {
+            cacheSubnetGroupName,
+            description: "Subnet group for Redis instance",
+            subnetIds: isPrivate
+                ? vpc.privateSubnets.map((subnet) => subnet.subnetId)
+                : vpc.publicSubnets.map((subnet) => subnet.subnetId),
+        }
+    );
+
+    const clusterName = `${scope.stackName}-eliza-redis`;
+    const redisInstance = new elasticache.CfnCacheCluster(scope, clusterName, {
+        autoMinorVersionUpgrade: true,
+        cacheNodeType: "cache.t4g.micro", // Small instance for cost optimization
+        cacheSubnetGroupName: subnetGroup.ref,
+        clusterName,
+        engine: "redis",
+        numCacheNodes: 1,
+        port: 6379,
+        vpcSecurityGroupIds: [securityGroup.securityGroupId],
+    });
+
+    return redisInstance;
+}


### PR DESCRIPTION
feat(cdk): add Redis security group and ElastiCache Redis instance for improved caching (#16)

- Introduced a new security group specifically for Redis instances to control network access.
- Implemented a function to create an ElastiCache Redis instance, enhancing caching and session management capabilities.
- Updated character configuration to include the new Redis instance, ensuring proper integration with the application.
- Refactored ElizaFleetStack to utilize the new Redis security group and instance, optimizing the infrastructure for better performance and security.