### PR TITLE
feat(cdk): enhance Eliza AI infrastructure with S3 bucket and IAM role updates

### DIFF
--- a/packages/cdk/src/aws/iam/createElizaTaskRole.ts
+++ b/packages/cdk/src/aws/iam/createElizaTaskRole.ts
@@ -1,4 +1,3 @@
-
 import * as iam from "aws-cdk-lib/aws-iam";
 import * as cdk from "aws-cdk-lib";
 
@@ -12,13 +11,7 @@ import * as cdk from "aws-cdk-lib";
  * @param scope - The CDK Stack scope to create the role in
  * @returns The created IAM role
  */
-export const createElizaTaskRole = (
-    {
-        scope,
-    }: {
-        scope: cdk.Stack;
-    }
-) => {
+export const createElizaTaskRole = ({ scope }: { scope: cdk.Stack }) => {
     const roleName = `${scope.stackName}-role`;
     const taskRole = new iam.Role(scope, roleName, {
         roleName,
@@ -26,27 +19,50 @@ export const createElizaTaskRole = (
     });
 
     // Add ECR pull permissions
-    taskRole.addToPolicy(new iam.PolicyStatement({
-        effect: iam.Effect.ALLOW,
-        actions: [
-            'ecr:GetAuthorizationToken',
-            'ecr:BatchCheckLayerAvailability',
-            'ecr:GetDownloadUrlForLayer',
-            'ecr:BatchGetImage'
-        ],
-        resources: ['*']
-    }));
+    taskRole.addToPolicy(
+        new iam.PolicyStatement({
+            effect: iam.Effect.ALLOW,
+            actions: [
+                "ecr:GetAuthorizationToken",
+                "ecr:BatchCheckLayerAvailability",
+                "ecr:GetDownloadUrlForLayer",
+                "ecr:BatchGetImage",
+            ],
+            resources: ["*"],
+        })
+    );
 
     // Add secrets manager policy
-    taskRole.addToPolicy(new iam.PolicyStatement({
-        effect: iam.Effect.ALLOW,
-        actions: ['secretsmanager:GetSecretValue'],
-        resources: ['*']
-    }));
+    taskRole.addToPolicy(
+        new iam.PolicyStatement({
+            effect: iam.Effect.ALLOW,
+            actions: ["secretsmanager:GetSecretValue"],
+            resources: ["*"],
+        })
+    );
+
+    // Add S3 permissions for the image bucket
+    taskRole.addToPolicy(
+        new iam.PolicyStatement({
+            effect: iam.Effect.ALLOW,
+            actions: [
+                "s3:GetObject",
+                "s3:PutObject",
+                "s3:DeleteObject",
+                "s3:ListBucket",
+            ],
+            resources: [
+                `arn:aws:s3:::${scope.stackName}-eliza-images`,
+                `arn:aws:s3:::${scope.stackName}-eliza-images/*`,
+            ],
+        })
+    );
 
     // Add execution role policy
     taskRole.addManagedPolicy(
-        iam.ManagedPolicy.fromAwsManagedPolicyName('service-role/AmazonECSTaskExecutionRolePolicy')
+        iam.ManagedPolicy.fromAwsManagedPolicyName(
+            "service-role/AmazonECSTaskExecutionRolePolicy"
+        )
     );
 
     return taskRole;

--- a/packages/cdk/src/aws/s3/createElizaImageBucket.ts
+++ b/packages/cdk/src/aws/s3/createElizaImageBucket.ts
@@ -1,0 +1,22 @@
+import * as cdk from "aws-cdk-lib";
+import * as s3 from "aws-cdk-lib/aws-s3";
+
+export const createElizaImageBucket = ({ scope }: { scope: cdk.Stack }) => {
+    const bucketName = `${scope.stackName}-eliza-images`;
+    const bucket = new s3.Bucket(scope, bucketName, {
+        bucketName,
+        versioned: true,
+        encryption: s3.BucketEncryption.S3_MANAGED,
+        publicReadAccess: false,
+        blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,
+        removalPolicy: cdk.RemovalPolicy.DESTROY,
+        autoDeleteObjects: true, // Enable this for development, consider changing for production
+        lifecycleRules: [
+            {
+                expiration: cdk.Duration.days(30), // Objects expire after 30 days
+            },
+        ],
+    });
+
+    return bucket;
+};

--- a/packages/cdk/src/config/characters.ts
+++ b/packages/cdk/src/config/characters.ts
@@ -1,7 +1,8 @@
 import * as cdk from "aws-cdk-lib";
 import * as ecs from "aws-cdk-lib/aws-ecs";
-import * as rds from "aws-cdk-lib/aws-rds";
 import * as elasticache from "aws-cdk-lib/aws-elasticache";
+import * as rds from "aws-cdk-lib/aws-rds";
+import * as s3 from "aws-cdk-lib/aws-s3";
 import { getECSSecret } from "../aws/secretsmanager/getECSSecret";
 
 export interface CharacterStackConfig {
@@ -15,10 +16,12 @@ export const buildCharacterConfig = ({
     scope,
     rdsInstance,
     redisInstance,
+    imageBucket,
 }: {
     scope: cdk.Stack;
     rdsInstance: rds.DatabaseInstance;
     redisInstance: elasticache.CfnCacheCluster;
+    imageBucket: s3.Bucket;
 }): CharacterStackConfig[] => [
     {
         name: "trump",
@@ -29,6 +32,8 @@ export const buildCharacterConfig = ({
             SERVER_PORT: "3000",
             TWITTER_DRY_RUN: "false",
             REDIS_URL: `redis://${redisInstance.attrRedisEndpointAddress}:${redisInstance.attrRedisEndpointPort}`,
+            AWS_S3_BUCKET: imageBucket.bucketName,
+            AWS_S3_UPLOAD_PATH: `trump/`,
         },
         secrets: {
             OPENAI_API_KEY: getECSSecret({

--- a/packages/cdk/src/stacks/ElizaFleetStack.ts
+++ b/packages/cdk/src/stacks/ElizaFleetStack.ts
@@ -13,6 +13,7 @@ import { createElizaRedisInstance } from "../aws/elasticache/createElizaRedisIns
 import { createECSSecurityGroup } from "../aws/ec2/createECSSecurityGroup";
 import { buildCharacterConfig } from "../config/characters";
 import { createElizaDockerAsset } from "../aws/ecr/createElizaDockerAsset";
+import { createElizaImageBucket } from "../aws/s3/createElizaImageBucket";
 
 export interface ElizaFleetStackProps extends cdk.StackProps {
     isPrivate: boolean;
@@ -30,6 +31,7 @@ export interface ElizaFleetStackProps extends cdk.StackProps {
  * 3. ECS Cluster for container orchestration
  * 4. Fargate Task Definition and Service
  * 5. Security Groups for network access control
+ * 6. S3 Bucket for storing Eliza-related images
  *
  * The stack supports two deployment modes:
  * - Private (isPrivate: true): More secure with private subnets and NAT Gateway
@@ -50,6 +52,7 @@ export class ElizaFleetStack extends cdk.Stack {
             scope: this,
             vpc,
         });
+        const imageBucket = createElizaImageBucket({ scope: this });
         const ecsSecurityGroup = createECSSecurityGroup({ scope: this, vpc });
 
         rdsSecurityGroup.addIngressRule(
@@ -89,6 +92,7 @@ export class ElizaFleetStack extends cdk.Stack {
             scope: this,
             rdsInstance,
             redisInstance,
+            imageBucket,
         });
 
         // Create services for each character


### PR DESCRIPTION
feat(cdk): enhance Eliza AI infrastructure with S3 bucket and IAM role updates

- Introduced a new S3 bucket for storing Eliza-related images, with versioning and lifecycle rules for object management.
- Refactored the IAM role creation to include additional S3 permissions, allowing for image upload and management.
- Updated character configuration to reference the new S3 bucket, ensuring proper integration with the Eliza AI application.
- Improved code readability by simplifying function signatures and restructuring policy statements for IAM roles.