### PR TITLE
fix(cdk): reduce memory limit in Eliza task definition from 16GB to 4GB

### DIFF
--- a/packages/cdk/src/aws/ecs/createElizaTaskDefinition.ts
+++ b/packages/cdk/src/aws/ecs/createElizaTaskDefinition.ts
@@ -33,7 +33,7 @@ export const createElizaTaskDefinition = ({
             //     cpuArchitecture: ecs.CpuArchitecture.ARM64,
             // },
             cpu: 2048,
-            memoryLimitMiB: 16384,
+            memoryLimitMiB: 4096,
             ephemeralStorageGiB: 50,
         }
     );


### PR DESCRIPTION
### TL;DR
Reduced the memory limit for the Eliza task definition from 16GB to 4GB.

### What changed?
Modified the `memoryLimitMiB` parameter in the Eliza task definition from 16384 (16GB) to 4096 (4GB).

### How to test?
1. Deploy the updated task definition
2. Monitor the ECS service to ensure it starts successfully
3. Verify that the application functions normally with the reduced memory allocation

### Why make this change?
The previous memory allocation of 16GB was likely overprovisioned for the actual needs of the application. Reducing it to 4GB optimizes resource utilization and reduces costs while maintaining sufficient memory for the service to operate effectively.