### PR TITLE
fix(cdk): reduce ephemeral storage in Eliza task definition from 50GB to 20GB

### DIFF
--- a/packages/cdk/src/aws/ecs/createElizaTaskDefinition.ts
+++ b/packages/cdk/src/aws/ecs/createElizaTaskDefinition.ts
@@ -34,7 +34,6 @@ export const createElizaTaskDefinition = ({
             // },
             cpu: 2048,
             memoryLimitMiB: 4096,
-            ephemeralStorageGiB: 50,
         }
     );
 


### PR DESCRIPTION
### TL;DR
Added Redis caching support to the ECS infrastructure and reduced memory allocation for task definitions.

### What changed?
- Added Redis ElastiCache instance with security group configuration
- Configured Redis connection details in character environment variables
- Reduced ECS task definition memory from 16GB to 4GB
- Changed caching strategy from database to Redis for Trump character
- Disabled automatic deployment on main branch pushes

### How to test?
1. Deploy the infrastructure changes using CDK
2. Verify Redis instance is created and accessible
3. Confirm ECS tasks can connect to Redis using the provided endpoint
4. Monitor memory usage of running tasks to ensure 4GB is sufficient

### Why make this change?
Redis provides better performance for caching compared to using the database directly. The memory reduction helps optimize costs while maintaining adequate resources for the application. The deployment trigger change allows for more controlled releases.