### PR TITLE
feat(client): add Vercel Speed Insights integration for performance monitoring

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -18,6 +18,7 @@
     "@radix-ui/react-tooltip": "1.1.4",
     "@tanstack/react-query": "5.61.0",
     "@vercel/analytics": "1.4.1",
+    "@vercel/speed-insights": "1.1.0",
     "class-variance-authority": "0.7.1",
     "clsx": "2.1.1",
     "lucide-react": "0.460.0",

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -4,7 +4,8 @@ import "./index.css";
 
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { RouterProvider } from "react-router-dom";
-import { Analytics } from "@vercel/analytics/react"
+import { Analytics } from "@vercel/analytics/react";
+import { SpeedInsights } from "@vercel/speed-insights/react";
 import { router } from "./router.tsx";
 // Create a client
 const queryClient = new QueryClient();
@@ -14,6 +15,7 @@ createRoot(document.getElementById("root")!).render(
         <QueryClientProvider client={queryClient}>
             <RouterProvider router={router} />
             <Analytics />
+            <SpeedInsights />
         </QueryClientProvider>
     </StrictMode>
 );

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -271,6 +271,9 @@ importers:
       '@vercel/analytics':
         specifier: 1.4.1
         version: 1.4.1(react@18.3.1)(svelte@5.15.0)(vue@3.5.13(typescript@5.6.3))
+      '@vercel/speed-insights':
+        specifier: 1.1.0
+        version: 1.1.0(react@18.3.1)(svelte@5.15.0)(vue@3.5.13(typescript@5.6.3))
       class-variance-authority:
         specifier: 0.7.1
         version: 0.7.1
@@ -8288,6 +8291,29 @@ packages:
     peerDependenciesMeta:
       '@remix-run/react':
         optional: true
+      '@sveltejs/kit':
+        optional: true
+      next:
+        optional: true
+      react:
+        optional: true
+      svelte:
+        optional: true
+      vue:
+        optional: true
+      vue-router:
+        optional: true
+
+  '@vercel/speed-insights@1.1.0':
+    resolution: {integrity: sha512-rAXxuhhO4mlRGC9noa5F7HLMtGg8YF1zAN6Pjd1Ny4pII4cerhtwSG4vympbCl+pWkH7nBS9kVXRD4FAn54dlg==}
+    peerDependencies:
+      '@sveltejs/kit': ^1 || ^2
+      next: '>= 13'
+      react: ^18 || ^19 || ^19.0.0-rc
+      svelte: '>= 4'
+      vue: ^3
+      vue-router: ^4
+    peerDependenciesMeta:
       '@sveltejs/kit':
         optional: true
       next:
@@ -28932,6 +28958,12 @@ snapshots:
       starknet: 6.18.0(encoding@0.1.13)
 
   '@vercel/analytics@1.4.1(react@18.3.1)(svelte@5.15.0)(vue@3.5.13(typescript@5.6.3))':
+    optionalDependencies:
+      react: 18.3.1
+      svelte: 5.15.0
+      vue: 3.5.13(typescript@5.6.3)
+
+  '@vercel/speed-insights@1.1.0(react@18.3.1)(svelte@5.15.0)(vue@3.5.13(typescript@5.6.3))':
     optionalDependencies:
       react: 18.3.1
       svelte: 5.15.0


### PR DESCRIPTION
feat(client): add Vercel Speed Insights integration for performance monitoring

- Included '@vercel/speed-insights' package in package.json to enable performance insights.
- Updated pnpm-lock.yaml to reflect the new dependency and its peer dependencies.
- Integrated Speed Insights component into the main application rendering for real-time performance tracking.

This change enhances the application's performance monitoring capabilities, providing valuable insights into user experience.