### PR TITLE
fix(deploy): use gha cache for faster builds

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -62,6 +62,11 @@ jobs:
             - name: Install dependencies
               run: pnpm install --frozen-lockfile
 
+            # This is required for the `gha` cache to work with CDK DockerImageAssets
+            # See https://docs.docker.com/build/cache/backends/gha/#authentication
+            - name: Expose GitHub Runtime
+              uses: crazy-max/ghaction-github-runtime@v3
+
             # Generate CDK diff for logging purposes
             - name: Generate CDK diff
               run: pnpm cdk diff --require-approval never eliza-fleet


### PR DESCRIPTION
### TL;DR
Added GitHub Runtime authentication to enable Docker image asset caching in CDK deployments.

### What changed?
Added the `crazy-max/ghaction-github-runtime@v3` action to the deployment workflow to authenticate and enable Docker image asset caching with GitHub Actions.

### How to test?
1. Trigger a deployment workflow
2. Verify that Docker image assets are properly cached between runs
3. Confirm that subsequent deployments are faster due to cache utilization

### Why make this change?
To improve deployment performance by enabling proper caching of Docker image assets in the CDK deployment process. This addresses a known requirement for GitHub Actions cache backend authentication when working with CDK DockerImageAssets.