### PR TITLE
fix(deploy): Github Actions out-of-space errors

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,8 +2,8 @@ name: Deploy
 
 on:
     push:
-        # branches:
-        #     - main
+        branches:
+            - main
 
 jobs:
     cdk_deploy_eliza_fleet:
@@ -60,9 +60,9 @@ jobs:
                   node-version-file: .nvmrc
                   cache: "pnpm"
 
-            # Above may restore cache directory, but we still need to install node_modules
+            # Only install node_modules for the cdk package to save space
             - name: Install dependencies
-              run: pnpm install --frozen-lockfile
+              run: pnpm install --filter=@elizaos/cdk --frozen-lockfile
 
             # This is required for the `gha` cache to work with CDK DockerImageAssets
             # See https://docs.docker.com/build/cache/backends/gha/#authentication

--- a/packages/cdk/src/aws/ecr/createElizaDockerAsset.ts
+++ b/packages/cdk/src/aws/ecr/createElizaDockerAsset.ts
@@ -36,8 +36,10 @@ export const createElizaDockerAsset = ({ scope }: { scope: cdk.Stack }) => {
         directory: projectRoot,
         ignoreMode: cdk.IgnoreMode.DOCKER, // Exclude files based on .dockerignore rules
         // Optimal caching for GitHub Actions https://benlimmer.com/2024/04/08/caching-cdk-dockerimageasset-github-actions/
-        cacheFrom: [{ type: "gha", params: { mode: "max" } }],
-        cacheTo: { type: "gha" },
         outputs: ["type=docker"],
+        cacheTo: { type: "gha" },
+        cacheFrom: [{ type: "gha" }],
+        // Not using max mode because it's causing out-of-disk-space errors in GitHub Actions
+        // cacheFrom: [{ type: "gha", params: { mode: "max" } }],
     });
 };


### PR DESCRIPTION
fix(deploy): optimize dependency installation in GitHub Actions workflow

- Updated the deployment workflow to only install node_modules for the @elizaos/cdk package, reducing space usage.
- This change streamlines the installation process and improves efficiency during deployments.

This adjustment enhances the overall performance of the deployment workflow by minimizing unnecessary installations.