### PR TITLE
add vercel analytics/SpeedInsights

### DIFF
--- a/client/src/app/layout.tsx
+++ b/client/src/app/layout.tsx
@@ -1,5 +1,7 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
+import { Analytics } from "@vercel/analytics/next";
+import { SpeedInsights } from "@vercel/speed-insights/next";
 import "./globals.css";
 
 const geistSans = Geist({
@@ -28,6 +30,8 @@ export default function RootLayout({
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
         {children}
+        <Analytics />
+        <SpeedInsights />
       </body>
     </html>
   );


### PR DESCRIPTION
### TL;DR
Added Vercel Analytics and Speed Insights tracking to the application

### What changed?
- Integrated `@vercel/analytics` component
- Added `@vercel/speed-insights` component
- Both components were added to the root layout to enable site-wide tracking

### How to test?
1. Visit any page on the application
2. Verify in the Vercel dashboard that analytics data is being collected
3. Confirm Speed Insights data appears in the Vercel dashboard after some user traffic

### Why make this change?
To gain insights into user behavior and monitor application performance metrics through Vercel's built-in analytics and speed monitoring tools. This will help identify areas for improvement and track user engagement.