### PR TITLE
fix(ecr): enable Docker outputs for Eliza Docker asset creation

### DIFF
--- a/packages/cdk/src/aws/ecr/createElizaDockerAsset.ts
+++ b/packages/cdk/src/aws/ecr/createElizaDockerAsset.ts
@@ -35,10 +35,10 @@ export const createElizaDockerAsset = ({ scope }: { scope: cdk.Stack }) => {
         assetName,
         directory: projectRoot,
         ignoreMode: cdk.IgnoreMode.DOCKER, // Exclude files based on .dockerignore rules
-        // cacheDisabled: true, // Github actions currently runs out of disk space when caching is enabled
+        cacheDisabled: true, // Github actions currently runs out of disk space when caching is enabled
+        outputs: ["type=docker"],
         // Optimal caching for GitHub Actions https://benlimmer.com/2024/04/08/caching-cdk-dockerimageasset-github-actions/
         // cacheFrom: [{ type: "gha" }],
         // cacheTo: { type: "gha" },
-        // outputs: ["type=docker"],
     });
 };


### PR DESCRIPTION
fix(ecr): enable Docker outputs for Eliza Docker asset creation

- Added 'outputs: ["type=docker"]' to the createElizaDockerAsset function to specify Docker outputs.
- This change enhances the asset creation process by ensuring that Docker outputs are properly defined, improving integration with Docker workflows.